### PR TITLE
feat: 서버 포트 환경변수화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
             "dependencies": {
                 "@types/express": "^5.0.0",
                 "@types/node": "^22.13.0",
-                "dotenv": "^16.4.7",
                 "express": "^4.21.2",
                 "swagger-cli": "^4.0.4",
                 "swagger-jsdoc": "^6.2.8",
@@ -1257,6 +1256,7 @@
             "version": "16.4.7",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
             "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+            "dev": true,
             "engines": {
                 "node": ">=12"
             },

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
         "build": "tsc",
         "test": "echo \"Error: no test specified\" && exit 1",
         "prestart": "npm run build",
-        "start": "node dist/main.js"
+        "start:dev": "node --env-file=.env dist/main.js",
+        "start": "node --env-file=.env.production dist/main.js"
     },
     "author": "",
     "license": "ISC",
     "dependencies": {
         "@types/express": "^5.0.0",
         "@types/node": "^22.13.0",
-        "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "swagger-cli": "^4.0.4",
         "swagger-jsdoc": "^6.2.8",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import Server from "./server/server";
 
-const server: Server = new Server(3000);
+const port: number = Number(process.env.SERVER_PORT);
+const server: Server = new Server(port);
 server.init();
 server.start();

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,8 +7,12 @@ class Server {
     app: express.Express;
     port?: number;
 
-    constructor(port: number) {
-        this.port = port ?? 3000;
+    constructor(port: number | undefined) {
+        if (!port || isNaN(port)) {
+            this.port = 3000;
+        } else {
+            this.port = port;
+        }
         this.app = express();
     }
 


### PR DESCRIPTION
feat: 서버 포트 환경변수화

- node20 버전 이후부터는 env 파일 읽기가 가능하므로 dotenv 의존성 제거
- npm start:dev / start 스크립트 분리
- 서버 포트 적용 로직 변경