### PR TITLE
update: 주문서 생성, 상세 조회 시 orgPrice, finalPrice 필드 추가, 두 필드 간의 계산 식 재정의

### DIFF
--- a/src/router/order/model/order.schema.ts
+++ b/src/router/order/model/order.schema.ts
@@ -25,6 +25,12 @@ export const orderSchema = new Schema({
                     type: String,
                 },
             },
+            orgPrice: {
+                type: Number,
+            },
+            finalPrice: {
+                type: Number,
+            },
         },
     ],
     totalPrice: {


### PR DESCRIPTION
orgPrice 계산:

옵션이 있고 optOrgPrice가 0이 아닌 경우: option.optOrgPrice 사용 그 외의 경우: productEntity.orgPrice 사용
finalPrice 계산:

옵션이 있는 경우: orgPrice + option.additionalPrice
옵션이 없는 경우: productEntity.finalPrice
옵셔널 체이닝(?.)으로 안전한 속성 접근

기본값 처리를 위한 널 병합 연산자(||)