### PR TITLE
fix: 주문 생성 시 상품 존재 확인 로직에서 같은 상품이 있는 경우 오류나는 문제 수정

### DIFF
--- a/src/router/order/order.service.ts
+++ b/src/router/order/order.service.ts
@@ -317,7 +317,13 @@ class OrderService {
         const products: Array<any> =
             await productRepository.findProductByIdsForOrder(productIds);
 
-        if (products.length !== body.products.length) {
+        // 상품의 갯수와 요청의 갯수 대신 products에 있는 상품이 body.products에 모두 존재하는지 ?
+        if (
+            !body.products.every((product) =>
+                products.find((p) => p._id.toString() === product.productId)
+            )
+        ) {
+            // if (products.length !== body.products.length) {
             return new ErrorDto(ERRCODE.E201);
         }
 


### PR DESCRIPTION
상품의 갯수만 단순히 일치하는 것을 비교하는 것이 아니라 모든 상품이 조회 한 상품 안에서 확인 되는 경우에 주문 생성